### PR TITLE
iOS: fix comment composer auto-closing when keyboard opens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+FloatNative is a pnpm + Gradle monorepo. The native apps in `apps/ios` (SwiftUI)
+and `apps/android` (Jetpack Compose) require Xcode / Android Studio and cannot be
+built or run on the Linux cloud VM. The runnable, testable backend here is the
+**TypeScript Companion API** (`packages/api`). Standard commands live in
+`README.md`, the root `package.json` scripts, and `packages/api/README.md`.
+
+### Running the Companion API locally (important gotchas)
+
+- Run it from `packages/api` with `npx wrangler dev` (Cloudflare Workers local,
+  port 8787, auto local SQLite via miniflare). Bindings show "local".
+- GOTCHA — do **not** rely on `pnpm api:dev` (i.e. `wrangler dev --env dev`) for
+  local testing as-is: `[[ratelimits]]` and several `[vars]` are defined only at
+  the top level of `packages/api/wrangler.toml`, and Wrangler does **not** inherit
+  them into the named `[env.dev]`. As a result every rate-limited route (including
+  `/` and `/health`) throws and returns `500` under `--env dev`. The default
+  (top-level) environment defines the rate limiters, so `npx wrangler dev` (no
+  `--env`) works for local testing.
+- The default env's local D1 database is `floatnative-db`; the `dev` env's is
+  `floatnative-db-dev`. Migrate whichever name matches the env you run.
+- The DB migration npm script only applies `migrations/0000_curious_ink.sql`.
+  For the full schema (the `device_sessions` table that auth depends on), also
+  apply `0001_drop_system_config.sql` and `0002_add_device_sessions.sql`, e.g.:
+  `npx wrangler d1 execute floatnative-db --local --file=./migrations/0002_add_device_sessions.sql`
+
+### Auth for local testing
+
+Authenticated endpoints (`/playlists/*`, `/watch-later/*`, `/ltt/*`) require an
+API key stored in `device_sessions`; obtaining one normally requires a real
+Floatplane OAuth login (external service). For local end-to-end testing, seed a
+`users` row plus a matching `device_sessions` row directly and use that
+`api_key` as the `Authorization: Bearer <key>` token, e.g.:
+
+```
+npx wrangler d1 execute floatnative-db --local --command "INSERT INTO users (floatplane_user_id, api_key) VALUES ('local-user','unused'); INSERT INTO device_sessions (id, floatplane_user_id, api_key, dpop_jkt) VALUES ('s1','local-user','local-api-key','jkt1');"
+```
+
+The hourly LTT-search scraper additionally needs a real `FLOATPLANE_SAILS_SID`
+secret; the rest of the API runs fine without it.
+
+### Other components
+
+- `apps/chrome-extension`: `pnpm extension:build` (webpack). Buildable here.
+- `packages/api-go`: an alternative self-hosting variant of the API. It targets
+  Go 1.23 (`go.mod`) and a Postgres stack via `docker-compose`. The base VM has
+  Go 1.22 and no Docker, so it does not build/run as-is — prefer the TS API for
+  local work unless Go 1.23 + Docker are provisioned.
+- `packages/openapi`: one-off Swift/Kotlin model codegen (needs Java + network).
+- `tools/floatcli`: Python diagnostic CLI; hits real Floatplane + the companion
+  API, so it needs live credentials.

--- a/apps/ios/FloatNative/Views/VideoPlayerView.swift
+++ b/apps/ios/FloatNative/Views/VideoPlayerView.swift
@@ -60,6 +60,12 @@ struct VideoPlayerView: View {
     // Quality selector state
     @State private var isChangingQuality = false
 
+    /// Tracks physical device orientation for UI that must stay visible while
+    /// the keyboard is open. GeometryReader width/height flips to "landscape"
+    /// when the keyboard shrinks the available height, which was removing the
+    /// comment composer and immediately dismissing focus.
+    @State private var isDeviceLandscape = false
+
     // Computed properties for UI
     private var hasLiked: Bool {
         userInteraction == .like
@@ -74,82 +80,74 @@ struct VideoPlayerView: View {
     }
 
     var body: some View {
-        GeometryReader { geometry in
-            let isLandscape = geometry.size.width > geometry.size.height
+        ZStack {
+            // Background
+            Color.adaptiveBackground
+                .ignoresSafeArea()
 
-            ZStack {
-                // Background
-                Color.adaptiveBackground
-                    .ignoresSafeArea()
+            // Persistent Layout (Always use portrait layout structure)
+            // When rotating to landscape, we trigger native fullscreen instead of swapping views
+            portraitLayout
 
-                // Persistent Layout (Always use portrait layout structure)
-                // When rotating to landscape, we trigger native fullscreen instead of swapping views
-                portraitLayout
+            // Error state
+            if let error = errorMessage {
+                VStack(spacing: 16) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: 50))
+                        .foregroundStyle(.red)
 
-                // Error state
-                if let error = errorMessage {
-                    VStack(spacing: 16) {
-                        Image(systemName: "exclamationmark.triangle")
-                            .font(.system(size: 50))
-                            .foregroundStyle(.red)
+                    Text(error)
+                        .foregroundStyle(Color.adaptiveText)
+                        .multilineTextAlignment(.center)
 
-                        Text(error)
-                            .foregroundStyle(Color.adaptiveText)
-                            .multilineTextAlignment(.center)
-
-                        Button("Retry") {
-                            Task {
-                                await loadVideo()
-                            }
+                    Button("Retry") {
+                        Task {
+                            await loadVideo()
                         }
-                        .buttonStyle(LiquidGlassButtonStyle(tint: .floatplaneBlue))
                     }
-                    .padding()
+                    .buttonStyle(LiquidGlassButtonStyle(tint: .floatplaneBlue))
                 }
+                .padding()
+            }
 
-                // Stream offline overlay (for livestreams that have ended)
-                if isStreamOffline && isLivestream {
-                    StreamOfflineOverlay {
-                        dismiss()
-                    }
-                }
-
-                // Bottom comment input overlay (only in portrait, not for livestreams, and when comments loaded successfully)
-                if !isLandscape && !isLivestream && !commentsLoadError {
-                    VStack {
-                        Spacer()
-                        bottomCommentInput
-                    }
+            // Stream offline overlay (for livestreams that have ended)
+            if isStreamOffline && isLivestream {
+                StreamOfflineOverlay {
+                    dismiss()
                 }
             }
-            #if !os(tvOS)
-            .navigationBarTitleDisplayMode(.inline)
-            #endif
-            .navigationBarBackButtonHidden(false) // Always show back button in "portrait" view
-            #if !os(tvOS)
-            .statusBar(hidden: false) // Always show status bar in "portrait" view
-            #endif
-            .toolbar(isLandscape ? .hidden : .visible, for: .tabBar)
-            .globalMenu()
-            // We listen to device orientation change because GeometryReader doesn't update
-            // reliably when the native player is in fullscreen mode (covering this view).
-            #if !os(tvOS)
-            .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
-                let orientation = UIDevice.current.orientation
-                
-                if orientation.isLandscape {
-                    AVPlayerManager.shared.enterFullScreen()
-                } else if orientation == .portrait {
-                    // Only exit fullscreen on standard portrait, ignore upside down
-                    AVPlayerManager.shared.exitFullScreen()
+
+            // Bottom comment input overlay (only in portrait, not for livestreams, and when comments loaded successfully)
+            if !isDeviceLandscape && !isLivestream && !commentsLoadError {
+                VStack {
+                    Spacer()
+                    bottomCommentInput
                 }
             }
-            #endif
         }
+        #if !os(tvOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .navigationBarBackButtonHidden(false) // Always show back button in "portrait" view
+        #if !os(tvOS)
+        .statusBar(hidden: false) // Always show status bar in "portrait" view
+        #endif
+        .toolbar(isDeviceLandscape ? .hidden : .visible, for: .tabBar)
+        .globalMenu()
+        // Device orientation drives landscape UI — not GeometryReader size, which
+        // falsely reads as landscape when the keyboard shrinks available height.
+        #if !os(tvOS)
+        .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+            handleDeviceOrientationChange(UIDevice.current.orientation)
+        }
+        #endif
         .onAppear {
             // Initialize like/dislike counts from post
             currentLikes = post.likes
             currentDislikes = post.dislikes
+            #if !os(tvOS)
+            handleDeviceOrientationChange(UIDevice.current.orientation)
+            #endif
         }
         .task {
             await loadVideo()
@@ -348,8 +346,23 @@ struct VideoPlayerView: View {
                 .padding()
                 .padding(.bottom, 100) // Space for floating comment input
             }
+            .scrollDismissesKeyboard(.never)
         }
     }
+
+    #if !os(tvOS)
+    /// Update landscape UI state and fullscreen player from a device orientation.
+    /// Ignores face-up/face-down/unknown so incidental motion doesn't flicker UI.
+    private func handleDeviceOrientationChange(_ orientation: UIDeviceOrientation) {
+        if orientation.isLandscape {
+            isDeviceLandscape = true
+            AVPlayerManager.shared.enterFullScreen()
+        } else if orientation == .portrait {
+            isDeviceLandscape = false
+            AVPlayerManager.shared.exitFullScreen()
+        }
+    }
+    #endif
 
     // MARK: - Load Video
 


### PR DESCRIPTION
Closes #46 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On iOS, tapping the comment composer (or Reply) would briefly show the keyboard, then immediately dismiss it — making it impossible to type a comment.

## Root cause

The floating comment input was only shown when `GeometryReader` reported portrait (`width <= height`). When the keyboard opens, the available view height shrinks enough that width exceeds height, so SwiftUI treated the layout as landscape, removed the `TextField` from the hierarchy, and focus was lost.

## Fix

- Track **device orientation** (`UIDevice.orientationDidChangeNotification`) for landscape UI gating instead of geometry size
- Add `.scrollDismissesKeyboard(.never)` on the comments `ScrollView` so incidental scrolling doesn't dismiss the keyboard

## Testing

Manual verification on iOS device/simulator:
1. Open a video post with comments
2. Tap the bottom comment field — keyboard should stay open
3. Tap Reply on a comment — keyboard should stay open with reply banner
4. Rotate to landscape — composer should still hide and fullscreen player should still engage
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-992aec46-c610-46b5-8633-770f092a0b57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-992aec46-c610-46b5-8633-770f092a0b57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

