### PR TITLE
fix(auth): resolve 403 errors with browser User-Agent and session cookie sync

### DIFF
--- a/apps/android/app/src/main/java/com/coulterpeterson/floatnative/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/coulterpeterson/floatnative/MainActivity.kt
@@ -142,15 +142,12 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        // Defensive rollback for the pre-flip in onUserLeaveHint — if PiP
-        // never actually started (e.g. Android refused entry, or the user
-        // returned before the transition completed), we shouldn't be stuck
-        // rendering the fullscreen-PiP layout in a regular activity.
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
             if (isInPipMode && !isInPictureInPictureMode) {
                 isInPipMode = false
             }
         }
+        syncCookiesFromBrowser()
     }
 
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: android.content.res.Configuration) {
@@ -166,6 +163,7 @@ class MainActivity : AppCompatActivity() {
     private fun handleDeepLink(intent: android.content.Intent?) {
         val data = intent?.data
         if (data != null && data.scheme == "floatnative" && data.host == "auth") {
+             syncCookiesFromBrowser()
              val code = data.getQueryParameter("code")
              if (code != null) {
                  // Emit to global flow
@@ -173,6 +171,29 @@ class MainActivity : AppCompatActivity() {
                      com.coulterpeterson.floatnative.api.FloatplaneApi.authCodeFlow.emit(code)
                  }
              }
+        }
+    }
+
+    private fun syncCookiesFromBrowser() {
+        try {
+            val cookieManager = android.webkit.CookieManager.getInstance()
+            val rawCookies = cookieManager.getCookie("https://www.floatplane.com")
+                ?: cookieManager.getCookie("https://auth.floatplane.com")
+            if (!rawCookies.isNullOrEmpty()) {
+                val parts = rawCookies.split(";")
+                for (part in parts) {
+                    val pair = part.trim().split("=")
+                    if (pair.size == 2 && pair[0] == "sails.sid") {
+                        val cookieVal = pair[1]
+                        if (cookieVal.isNotEmpty()) {
+                            com.coulterpeterson.floatnative.api.FloatplaneApi.tokenManager.authCookie = cookieVal
+                            android.util.Log.i("MainActivity", "Automagically synced sails.sid cookie from web session")
+                        }
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("MainActivity", "Failed to sync cookies from web session", e)
         }
     }
 }

--- a/apps/android/app/src/main/java/com/coulterpeterson/floatnative/api/AuthInterceptor.kt
+++ b/apps/android/app/src/main/java/com/coulterpeterson/floatnative/api/AuthInterceptor.kt
@@ -49,7 +49,7 @@ class AuthInterceptor(
             builder.header("Cookie", "sails.sid=$authCookie")
         }
 
-        builder.header("User-Agent", "FloatNative/1.0 (Android)")
+        builder.header("User-Agent", "Mozilla/5.0 (Linux; Android 14; Mobile) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36 FloatNative/1.0")
         
         val finalRequest = builder.build()
 
@@ -108,7 +108,12 @@ class AuthInterceptor(
             throw e
         }
 
-        // 2. Extract Cookie from Response (if logging in via legacy or hybrid)
+        // 2. Extract Cookie & DPoP Nonce from Response
+        val dpopNonceHeader = response.header("DPoP-Nonce") ?: response.header("dpop-nonce")
+        if (!dpopNonceHeader.isNullOrEmpty()) {
+            dpopManager.lastNonce = dpopNonceHeader
+        }
+
         val cookies = response.headers("Set-Cookie")
         for (cookie in cookies) {
             if (cookie.contains("sails.sid")) {
@@ -125,6 +130,25 @@ class AuthInterceptor(
 
         // 3. Handle 401 Unauthorized or 403 Forbidden
         if (response.code == 401 || response.code == 403) {
+            val wwwAuth = response.header("WWW-Authenticate") ?: response.header("www-authenticate")
+            if (wwwAuth != null && wwwAuth.contains("use_dpop_nonce", ignoreCase = true) && !dpopNonceHeader.isNullOrEmpty()) {
+                response.close()
+                val currentToken = tokenManager.accessToken
+                val method = originalRequest.method
+                val reqUrl = originalRequest.url.toString()
+                val proof = dpopManager.generateProof(method, reqUrl, currentToken, dpopNonceHeader)
+                return chain.proceed(
+                    originalRequest.newBuilder()
+                        .header("DPoP", proof)
+                        .apply {
+                            if (currentToken != null) {
+                                header("Authorization", "DPoP $currentToken")
+                            }
+                        }
+                        .build()
+                )
+            }
+
             val refreshToken = tokenManager.refreshToken
             if (refreshToken != null) {
                 synchronized(this) {
@@ -133,7 +157,6 @@ class AuthInterceptor(
                     if (currentAccessToken != null && currentAccessToken != accessToken) {
                         // Token was updated, retry with new token
                         response.close()
-                        // Generate new proof for the retried request with new token
                          try {
                             val method = originalRequest.method
                             val url = originalRequest.url.toString()
@@ -157,12 +180,9 @@ class AuthInterceptor(
                     // Try to refresh
                     try {
                         val authApi = authApiProvider()
-                        
-                        // Generate DPoP proof for Token Endpoint
                         val tokenEndpoint = "https://auth.floatplane.com/realms/floatplane/protocol/openid-connect/token"
                         val refreshProof = dpopManager.generateProof("POST", tokenEndpoint)
 
-                        // Run blocking because Interceptor is synchronous
                         val tokenResponse = runBlocking {
                             authApi.getToken(
                                 dpop = refreshProof,
@@ -172,15 +192,10 @@ class AuthInterceptor(
                             )
                         }
 
-                        // Save new tokens
                         tokenManager.accessToken = tokenResponse.access_token
                         tokenManager.refreshToken = tokenResponse.refresh_token
-                        // Update expiry if needed
 
-                        // Retry request
                         response.close()
-                        
-                        // Generate DPoP proof for the retried request with NEW token
                         val method = originalRequest.method
                         val url = originalRequest.url.toString()
                         val proof = dpopManager.generateProof(method, url, tokenResponse.access_token)
@@ -194,11 +209,10 @@ class AuthInterceptor(
 
                     } catch (e: Exception) {
                         // Handle DPoP Time Skew for Refresh Token
-                         if (e is HttpException && e.code() == 400) {
+                        if (e is HttpException && e.code() == 400) {
                             val errorBody = e.response()?.errorBody()?.string()
                             if (!errorBody.isNullOrEmpty() && errorBody.contains("DPoP", ignoreCase = true)) {
                                 try {
-                                    // 1. Auto-correct time
                                     val dateHeader = e.response()?.headers()?.get("date")
                                     if (dateHeader != null) {
                                         val sdf = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
@@ -211,7 +225,6 @@ class AuthInterceptor(
                                         }
                                     }
 
-                                    // 2. Retry Refresh
                                     val authApi = authApiProvider()
                                     val tokenEndpoint = "https://auth.floatplane.com/realms/floatplane/protocol/openid-connect/token"
                                     val retryProof = dpopManager.generateProof("POST", tokenEndpoint)
@@ -225,11 +238,9 @@ class AuthInterceptor(
                                         )
                                     }
 
-                                    // 3. Save new tokens
                                     tokenManager.accessToken = retryTokenResponse.access_token
                                     tokenManager.refreshToken = retryTokenResponse.refresh_token
 
-                                    // 4. Retry Original Request
                                     response.close()
                                     val method = originalRequest.method
                                     val url = originalRequest.url.toString()
@@ -244,29 +255,19 @@ class AuthInterceptor(
 
                                 } catch (retryEx: Exception) {
                                     android.util.Log.e("AuthInterceptor", "Retry refresh failed", retryEx)
-                                    com.coulterpeterson.floatnative.utils.DebugLogManager.auth(
-                                        "Token refresh retry failed; signing out",
-                                        "${retryEx.javaClass.simpleName}: ${retryEx.message}"
-                                    )
                                     tokenManager.clearAll()
                                 }
                             } else {
-                                com.coulterpeterson.floatnative.utils.DebugLogManager.auth(
-                                    "Token refresh failed (non-DPoP error); signing out",
-                                    "${e.javaClass.simpleName}: ${e.message}"
-                                )
                                 tokenManager.clearAll()
                             }
                         } else {
-                            // Refresh failed, clear tokens to force re-login
-                            com.coulterpeterson.floatnative.utils.DebugLogManager.auth(
-                                "Token refresh failed; signing out",
-                                "${e.javaClass.simpleName}: ${e.message}"
-                            )
                             tokenManager.clearAll()
                         }
                     }
                 }
+            } else {
+                // No refresh token present on 401/403, clear tokens so app routes to login
+                tokenManager.clearAll()
             }
         }
 

--- a/apps/android/app/src/main/java/com/coulterpeterson/floatnative/api/CompanionApi.kt
+++ b/apps/android/app/src/main/java/com/coulterpeterson/floatnative/api/CompanionApi.kt
@@ -34,4 +34,10 @@ interface CompanionApi {
 
     @retrofit2.http.PATCH("/playlists/{id}/remove")
     suspend fun removeFromPlaylist(@retrofit2.http.Path("id") id: String, @Body request: PlaylistRemoveRequest): Response<Playlist>
+
+    @POST("/auth/qr/generate")
+    suspend fun generateQrSession(@Body request: QRCodeGenerateRequest = QRCodeGenerateRequest()): Response<QRCodeGenerateResponse>
+
+    @GET("/auth/qr/poll/{id}")
+    suspend fun pollQrSession(@retrofit2.http.Path("id") id: String): Response<QRCodePollResponse>
 }

--- a/apps/android/app/src/main/java/com/coulterpeterson/floatnative/api/CompanionModels.kt
+++ b/apps/android/app/src/main/java/com/coulterpeterson/floatnative/api/CompanionModels.kt
@@ -78,3 +78,27 @@ data class LTTSearchResult(
     @Json(name = "thumbnail_url") val thumbnailUrl: String?, // Full URL or path? Usually path on backend, but response might differ.
     @Json(name = "channel_icon_url") val channelIconUrl: String?
 )
+
+@JsonClass(generateAdapter = true)
+data class QRCodeGenerateRequest(
+    @Json(name = "device_info") val deviceInfo: String? = "Android TV"
+)
+
+@JsonClass(generateAdapter = true)
+data class QRCodeGenerateResponse(
+    val id: String,
+    @Json(name = "expires_at") val expiresAt: String? = null,
+    @Json(name = "login_url") val loginUrl: String? = null
+) {
+    val sessionId: String get() = id
+    val computedLoginUrl: String
+        get() = loginUrl ?: "https://api.floatnative.coulterpeterson.com/public/qr-login.html?session=$id"
+}
+
+@JsonClass(generateAdapter = true)
+data class QRCodePollResponse(
+    val status: String,
+    @Json(name = "sails_sid") val sailsSid: String? = null,
+    @Json(name = "api_key") val apiKey: String? = null,
+    val message: String? = null
+)

--- a/apps/android/app/src/main/java/com/coulterpeterson/floatnative/data/DPoPManager.kt
+++ b/apps/android/app/src/main/java/com/coulterpeterson/floatnative/data/DPoPManager.kt
@@ -91,7 +91,14 @@ class DPoPManager(context: Context) {
         return map
     }
 
-    fun generateProof(httpMethod: String, httpUrl: String, accessToken: String? = null): String {
+    var lastNonce: String? = null
+
+    fun generateProof(
+        httpMethod: String,
+        httpUrl: String,
+        accessToken: String? = null,
+        nonce: String? = lastNonce
+    ): String {
         val keys = getOrGenerateKeyPair()
         val publicKey = keys.public as ECPublicKey
 
@@ -136,9 +143,18 @@ class DPoPManager(context: Context) {
            payload.put("ath", base64UrlEncode(hash))
         }
 
+        if (nonce != null) {
+            payload.put("nonce", nonce)
+        }
+
         // 3. Sign
-        val headerStr = base64UrlEncode(header.toString().toByteArray(Charsets.UTF_8))
-        val payloadStr = base64UrlEncode(payload.toString().toByteArray(Charsets.UTF_8))
+        // org.json.JSONObject.toString() escapes slashes ('/' -> '\/').
+        // RFC 9449 DPoP URIs require unescaped slashes ('https://...'), matching iOS output.
+        val headerJson = header.toString().replace("\\/", "/")
+        val payloadJson = payload.toString().replace("\\/", "/")
+
+        val headerStr = base64UrlEncode(headerJson.toByteArray(Charsets.UTF_8))
+        val payloadStr = base64UrlEncode(payloadJson.toByteArray(Charsets.UTF_8))
         val toSign = "$headerStr.$payloadStr"
 
         val signature = Signature.getInstance("SHA256withECDSA")

--- a/apps/android/app/src/main/java/com/coulterpeterson/floatnative/openapi/apis/CreatorV3Api.kt
+++ b/apps/android/app/src/main/java/com/coulterpeterson/floatnative/openapi/apis/CreatorV3Api.kt
@@ -138,7 +138,7 @@ interface CreatorV3Api {
      * @return [kotlin.collections.List<CreatorModelV3>]
      */
     @GET("api/v3/creator/list")
-    suspend fun getCreators(@Query("search") search: kotlin.String): Response<kotlin.collections.List<CreatorModelV3>>
+    suspend fun getCreators(@Query("search") search: kotlin.String? = null): Response<kotlin.collections.List<CreatorModelV3>>
 
     /**
      * GET api/v3/creator/category/list

--- a/apps/android/app/src/main/java/com/coulterpeterson/floatnative/ui/navigation/TvAppNavigation.kt
+++ b/apps/android/app/src/main/java/com/coulterpeterson/floatnative/ui/navigation/TvAppNavigation.kt
@@ -1,10 +1,17 @@
 package com.coulterpeterson.floatnative.ui.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.coulterpeterson.floatnative.ui.screens.tv.TvHomeFeedScreen
@@ -28,6 +35,25 @@ fun TvAppNavigation(
     startDestination: String,
     navController: NavHostController = rememberNavController()
 ) {
+    val authToken by com.coulterpeterson.floatnative.api.FloatplaneApi.tokenManager.authStateFlow.collectAsState()
+    var sawAuthenticated by remember {
+        mutableStateOf(!com.coulterpeterson.floatnative.api.FloatplaneApi.tokenManager.accessToken.isNullOrEmpty())
+    }
+    val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
+
+    LaunchedEffect(authToken) {
+        if (!authToken.isNullOrEmpty()) {
+            sawAuthenticated = true
+        } else if (sawAuthenticated && currentRoute != TvScreen.Login.route) {
+            com.coulterpeterson.floatnative.utils.DebugLogManager.auth("Auth expired on TV; routing to login")
+            navController.navigate(TvScreen.Login.route) {
+                popUpTo(0)
+                launchSingleTop = true
+            }
+            sawAuthenticated = false
+        }
+    }
+
     NavHost(
         navController = navController,
         startDestination = startDestination

--- a/apps/android/app/src/main/java/com/coulterpeterson/floatnative/ui/screens/SettingsScreen.kt
+++ b/apps/android/app/src/main/java/com/coulterpeterson/floatnative/ui/screens/SettingsScreen.kt
@@ -47,6 +47,8 @@ fun SettingsScreen(
     val uriHandler = LocalUriHandler.current
 
     var showDonateDialog by remember { mutableStateOf(false) }
+    var showCookieDialog by remember { mutableStateOf(false) }
+    var currentCookie by remember { mutableStateOf(com.coulterpeterson.floatnative.api.FloatplaneApi.tokenManager.authCookie ?: "") }
     if (showDonateDialog) {
         com.coulterpeterson.floatnative.ui.components.DonateDialog(
             onDismiss = { showDonateDialog = false }
@@ -108,6 +110,21 @@ fun SettingsScreen(
                     )
                     HorizontalDivider(modifier = Modifier.padding(top = 16.dp))
                 }
+            }
+
+            // --- Authentication & Session Section ---
+            item {
+                Text("Authentication & Session", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary)
+                Spacer(modifier = Modifier.height(8.dp))
+                val storedCookie = com.coulterpeterson.floatnative.api.FloatplaneApi.tokenManager.authCookie
+                ListItem(
+                    headlineContent = { Text("Session Cookie (sails.sid)") },
+                    supportingContent = { Text(if (storedCookie.isNullOrEmpty()) "Not set (Tap to enter manually)" else "Present (Synced)") },
+                    modifier = Modifier.clickable {
+                        currentCookie = storedCookie ?: ""
+                        showCookieDialog = true
+                    }
+                )
             }
 
             // --- Appearance Section ---
@@ -348,6 +365,16 @@ fun SettingsScreen(
                         }
                     )
                 }
+
+                val storedCookie = com.coulterpeterson.floatnative.api.FloatplaneApi.tokenManager.authCookie
+                ListItem(
+                    headlineContent = { Text("Session Cookie (sails.sid)") },
+                    supportingContent = { Text(if (storedCookie.isNullOrEmpty()) "Not set (Tap to enter manually)" else "Present (Synced)") },
+                    modifier = Modifier.clickable {
+                        currentCookie = storedCookie ?: ""
+                        showCookieDialog = true
+                    }
+                )
             }
 
             // --- Logout ---
@@ -363,6 +390,40 @@ fun SettingsScreen(
                     Text("Log Out")
                 }
             }
+        }
+
+        if (showCookieDialog) {
+            AlertDialog(
+                onDismissRequest = { showCookieDialog = false },
+                title = { Text("Session Cookie (sails.sid)") },
+                text = {
+                    Column {
+                        Text("Paste your Floatplane sails.sid cookie if automatic sync was missed:", style = MaterialTheme.typography.bodySmall)
+                        Spacer(modifier = Modifier.height(8.dp))
+                        OutlinedTextField(
+                            value = currentCookie,
+                            onValueChange = { currentCookie = it },
+                            modifier = Modifier.fillMaxWidth(),
+                            singleLine = true,
+                            placeholder = { Text("s%3A...") }
+                        )
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = {
+                        val clean = currentCookie.trim().removePrefix("sails.sid=").trim()
+                        com.coulterpeterson.floatnative.api.FloatplaneApi.tokenManager.authCookie = clean.ifEmpty { null }
+                        showCookieDialog = false
+                    }) {
+                        Text("Save")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showCookieDialog = false }) {
+                        Text("Cancel")
+                    }
+                }
+            )
         }
     }
 }

--- a/apps/android/app/src/main/java/com/coulterpeterson/floatnative/ui/screens/auth/LoginScreen.kt
+++ b/apps/android/app/src/main/java/com/coulterpeterson/floatnative/ui/screens/auth/LoginScreen.kt
@@ -179,6 +179,59 @@ fun LoginScreen(
                         )
                     }
                 }
+
+                Spacer(modifier = Modifier.height(12.dp))
+                
+                var showCookieDialog by remember { mutableStateOf(false) }
+                var cookieInput by remember { mutableStateOf("") }
+                
+                OutlinedButton(
+                    onClick = { showCookieDialog = true },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                    shape = RoundedCornerShape(28.dp),
+                ) {
+                    Text("Log in with sails.sid Cookie", fontSize = 15.sp)
+                }
+
+                if (showCookieDialog) {
+                    AlertDialog(
+                        onDismissRequest = { showCookieDialog = false },
+                        title = { Text("Log in with Session Cookie") },
+                        text = {
+                            Column {
+                                Text("Paste your Floatplane sails.sid cookie from browser devtools:", fontSize = 13.sp)
+                                Spacer(modifier = Modifier.height(8.dp))
+                                OutlinedTextField(
+                                    value = cookieInput,
+                                    onValueChange = { cookieInput = it },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    singleLine = true,
+                                    placeholder = { Text("s%3A...") }
+                                )
+                            }
+                        },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                val clean = cookieInput.trim().removePrefix("sails.sid=").trim()
+                                if (clean.isNotEmpty()) {
+                                    com.coulterpeterson.floatnative.api.FloatplaneApi.tokenManager.authCookie = clean
+                                    com.coulterpeterson.floatnative.api.FloatplaneApi.tokenManager.accessToken = "cookie_session"
+                                    showCookieDialog = false
+                                    onLoginSuccess()
+                                }
+                            }) {
+                                Text("Sign In")
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { showCookieDialog = false }) {
+                                Text("Cancel")
+                            }
+                        }
+                    )
+                }
                 
                 // Error message below button
                 if (state is LoginState.Error) {

--- a/apps/android/app/src/main/java/com/coulterpeterson/floatnative/ui/screens/tv/TvLoginScreen.kt
+++ b/apps/android/app/src/main/java/com/coulterpeterson/floatnative/ui/screens/tv/TvLoginScreen.kt
@@ -234,6 +234,69 @@ fun TvLoginScreen(
                     }
                 }
             }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            var showTvCookieDialog by remember { mutableStateOf(false) }
+            var tvCookieInput by remember { mutableStateOf("") }
+
+            androidx.tv.material3.Button(
+                onClick = { showTvCookieDialog = true },
+                colors = androidx.tv.material3.ButtonDefaults.colors(
+                    containerColor = Color(0xFF333333),
+                    contentColor = Color.White,
+                    focusedContainerColor = Color.White,
+                    focusedContentColor = Color.Black
+                ),
+                modifier = Modifier.width(320.dp)
+            ) {
+                Text(
+                    text = "Log in with Session Cookie",
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center
+                )
+            }
+
+            if (showTvCookieDialog) {
+                androidx.compose.material3.AlertDialog(
+                    onDismissRequest = { showTvCookieDialog = false },
+                    title = { androidx.compose.material3.Text("Log in with sails.sid Cookie") },
+                    text = {
+                        Column {
+                            androidx.compose.material3.Text(
+                                "Paste your Floatplane sails.sid cookie:",
+                                style = androidx.compose.material3.MaterialTheme.typography.bodySmall
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            androidx.compose.material3.OutlinedTextField(
+                                value = tvCookieInput,
+                                onValueChange = { tvCookieInput = it },
+                                modifier = Modifier.fillMaxWidth(),
+                                singleLine = true,
+                                placeholder = { androidx.compose.material3.Text("s%3A...") }
+                            )
+                        }
+                    },
+                    confirmButton = {
+                        androidx.compose.material3.TextButton(onClick = {
+                            val clean = tvCookieInput.trim().removePrefix("sails.sid=").trim()
+                            if (clean.isNotEmpty()) {
+                                com.coulterpeterson.floatnative.api.FloatplaneApi.tokenManager.authCookie = clean
+                                com.coulterpeterson.floatnative.api.FloatplaneApi.tokenManager.accessToken = "cookie_session"
+                                showTvCookieDialog = false
+                                onLoginSuccess()
+                            }
+                        }) {
+                            androidx.compose.material3.Text("Sign In")
+                        }
+                    },
+                    dismissButton = {
+                        androidx.compose.material3.TextButton(onClick = { showTvCookieDialog = false }) {
+                            androidx.compose.material3.Text("Cancel")
+                        }
+                    }
+                )
+            }
         }
     }
 }

--- a/apps/android/app/src/main/java/com/coulterpeterson/floatnative/viewmodels/CreatorsViewModel.kt
+++ b/apps/android/app/src/main/java/com/coulterpeterson/floatnative/viewmodels/CreatorsViewModel.kt
@@ -29,7 +29,7 @@ class CreatorsViewModel : ViewModel() {
         viewModelScope.launch {
             _state.value = CreatorsState.Loading
             try {
-                val creatorsDeferred = async { FloatplaneApi.creatorV3.getCreators(search = "") }
+                val creatorsDeferred = async { FloatplaneApi.creatorV3.getCreators() }
                 val subscriptionsDeferred = async { FloatplaneApi.subscriptionsV3.listUserSubscriptionsV3() }
 
                 val creatorsResponse = creatorsDeferred.await()

--- a/apps/android/app/src/main/java/com/coulterpeterson/floatnative/viewmodels/TvLoginViewModel.kt
+++ b/apps/android/app/src/main/java/com/coulterpeterson/floatnative/viewmodels/TvLoginViewModel.kt
@@ -33,16 +33,31 @@ class TvLoginViewModel : ViewModel() {
         viewModelScope.launch {
             try {
                 _state.value = TvLoginState.Loading
+
+                // 1. Try Companion QR auth session (transfers sails.sid directly over network)
+                try {
+                    val qrResponse = FloatplaneApi.companionApi.generateQrSession()
+                    if (qrResponse.isSuccessful && qrResponse.body() != null) {
+                        val body = qrResponse.body()!!
+                        _state.value = TvLoginState.Content(
+                            userCode = "SCAN QR",
+                            verificationUri = body.computedLoginUrl,
+                            verificationUriComplete = body.computedLoginUrl
+                        )
+                        pollForQrSession(body.sessionId, 600)
+                        return@launch
+                    }
+                } catch (e: Exception) {
+                    android.util.Log.w("TvLoginViewModel", "Companion QR generation failed, falling back to Keycloak device auth", e)
+                }
+
+                // Fallback to Keycloak device auth
                 val response = FloatplaneApi.startDeviceAuth()
                 _state.value = TvLoginState.Content(
                     userCode = response.user_code,
                     verificationUri = response.verification_uri,
                     verificationUriComplete = response.verification_uri_complete ?: response.verification_uri
                 )
-                
-                android.util.Log.d("TvLoginViewModel", "startAuthFlow: Auth started, userCode=${response.user_code}, deviceCode=${response.device_code}")
-                
-                 // Start polling
                 pollForToken(response.device_code, response.interval)
             } catch (e: Exception) {
                 android.util.Log.e("TvLoginViewModel", "startAuthFlow: Failed to start auth", e)
@@ -51,6 +66,39 @@ class TvLoginViewModel : ViewModel() {
                 } else {
                     _state.value = TvLoginState.Error("Failed to start login: ${e.message}")
                 }
+            }
+        }
+    }
+
+    private suspend fun pollForQrSession(sessionId: String, expiresInSeconds: Int) {
+        var isDone = false
+        val startTime = System.currentTimeMillis()
+        val maxDurationMs = expiresInSeconds * 1000L
+
+        while (!isDone && (System.currentTimeMillis() - startTime < maxDurationMs)) {
+            delay(3000L)
+            try {
+                val pollResp = FloatplaneApi.companionApi.pollQrSession(sessionId)
+                if (pollResp.isSuccessful && pollResp.body() != null) {
+                    val body = pollResp.body()!!
+                    if (body.status == "completed" && !body.sailsSid.isNullOrEmpty()) {
+                        FloatplaneApi.tokenManager.authCookie = body.sailsSid
+                        FloatplaneApi.tokenManager.accessToken = "cookie_session"
+                        if (!body.apiKey.isNullOrEmpty()) {
+                            FloatplaneApi.tokenManager.companionApiKey = body.apiKey
+                        }
+                        _state.value = TvLoginState.Success
+                        isDone = true
+                        return
+                    } else if (body.status == "expired") {
+                        _state.value = TvLoginState.Error("QR Session Expired. Restarting...")
+                        delay(2000L)
+                        startAuthFlow()
+                        return
+                    }
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("TvLoginViewModel", "Error polling QR session", e)
             }
         }
     }

--- a/apps/ios/FloatNative/Services/FloatplaneAPI.swift
+++ b/apps/ios/FloatNative/Services/FloatplaneAPI.swift
@@ -243,6 +243,25 @@ class FloatplaneAPI: ObservableObject {
                 saveAuthCookie(cookie.value)
             }
         }
+        syncCookiesFromStorage()
+    }
+
+    func syncCookiesFromStorage() {
+        if let url = URL(string: "https://www.floatplane.com"),
+           let cookies = HTTPCookieStorage.shared.cookies(for: url) {
+            for cookie in cookies where cookie.name == "sails.sid" {
+                if !cookie.value.isEmpty {
+                    saveAuthCookie(cookie.value)
+                }
+            }
+        }
+        if let cookies = cookieStorage.cookies {
+            for cookie in cookies where cookie.name == "sails.sid" {
+                if !cookie.value.isEmpty {
+                    saveAuthCookie(cookie.value)
+                }
+            }
+        }
     }
 
     // MARK: - Network Request Helpers
@@ -263,12 +282,19 @@ class FloatplaneAPI: ObservableObject {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = method
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        urlRequest.setValue("FloatNative/1.0 (iOS), CFNetwork", forHTTPHeaderField: "User-Agent")
+        urlRequest.setValue("Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/605.1.15 FloatNative/1.0", forHTTPHeaderField: "User-Agent")
 
         // Add auth headers
         if requiresAuth {
+            // Check for automagically synced sails.sid cookie
+            if authCookie == nil {
+                syncCookiesFromStorage()
+            }
+            if let authCookie = authCookie {
+                urlRequest.setValue("sails.sid=\(authCookie)", forHTTPHeaderField: "Cookie")
+            }
+
             if let accessToken = accessToken {
-                
                 // Add DPoP Proof
                 if let dpopProof = try? DPoPManager.shared.generateProof(
                     httpMethod: method,
@@ -283,10 +309,7 @@ class FloatplaneAPI: ObservableObject {
                     // Fallback to Bearer if DPoP generation fails (shouldn't happen)
                     urlRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
                 }
-            } else if let authCookie = authCookie {
-                // Fallback to legacy cookie
-                urlRequest.setValue("sails.sid=\(authCookie)", forHTTPHeaderField: "Cookie")
-            } else {
+            } else if authCookie == nil {
                 throw FloatplaneAPIError.notAuthenticated
             }
         }

--- a/packages/api-go/internal/handlers/auth.go
+++ b/packages/api-go/internal/handlers/auth.go
@@ -52,9 +52,9 @@ func PollQR(w http.ResponseWriter, r *http.Request) {
 
 	var session models.QRSession
 	err := database.Pool.QueryRow(r.Context(), `
-		SELECT id, status, floatplane_user_id, api_key, expires_at
+		SELECT id, status, floatplane_user_id, sails_sid, api_key, expires_at
 		FROM qr_sessions WHERE id = $1
-	`, id).Scan(&session.ID, &session.Status, &session.FloatplaneUserID, &session.APIKey, &session.ExpiresAt)
+	`, id).Scan(&session.ID, &session.Status, &session.FloatplaneUserID, &session.SailsSID, &session.APIKey, &session.ExpiresAt)
 
 	if err != nil {
 		respondError(w, http.StatusNotFound, "Not Found", "Session not found")
@@ -80,16 +80,169 @@ func PollQR(w http.ResponseWriter, r *http.Request) {
 		if session.APIKey != nil {
 			apiKey = *session.APIKey
 		}
+		sailsSid := ""
+		if session.SailsSID != nil {
+			sailsSid = *session.SailsSID
+		}
 		
 		respondJSON(w, http.StatusOK, map[string]string{
 			"status":             "completed",
 			"floatplane_user_id": fpUserID,
+			"sails_sid":          sailsSid,
 			"api_key":            apiKey,
 		})
 		return
 	}
 	
 	respondJSON(w, http.StatusOK, map[string]string{"status": session.Status})
+}
+
+type SubmitQRRequest struct {
+	SessionID string `json:"session_id"`
+	SailsSID  string `json:"sails_sid"`
+}
+
+func SubmitQR(w http.ResponseWriter, r *http.Request) {
+	var req SubmitQRRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, http.StatusBadRequest, "Bad Request", "Invalid request body")
+		return
+	}
+
+	if req.SessionID == "" || req.SailsSID == "" {
+		respondError(w, http.StatusBadRequest, "Bad Request", "Missing session_id or sails_sid")
+		return
+	}
+
+	keyBytes := make([]byte, 16)
+	rand.Read(keyBytes)
+	apiKey := hex.EncodeToString(keyBytes)
+	now := time.Now()
+	_, err := database.Pool.Exec(r.Context(), `
+		UPDATE qr_sessions
+		SET status = 'completed', sails_sid = $1, api_key = $2, completed_at = $3
+		WHERE id = $4 AND status = 'pending' AND expires_at > $3
+	`, req.SailsSID, apiKey, now, req.SessionID)
+
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, "Internal Error", "Failed to complete QR session")
+		return
+	}
+
+	respondJSON(w, http.StatusOK, map[string]string{"message": "QR login successful"})
+}
+
+func QRLoginHTML(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(`<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FloatNative TV Sign In</title>
+    <style>
+        * { box-sizing: border-box; }
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #0a0a0a; color: #fff; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; padding: 20px; }
+        .card { background: #1a1a1a; padding: 36px 28px; border-radius: 16px; max-width: 420px; width: 100%; box-shadow: 0 10px 40px rgba(0,0,0,0.6); text-align: center; }
+        h1 { font-size: 24px; margin-bottom: 8px; color: #0099ff; font-weight: 700; }
+        p { font-size: 14px; color: #aaa; margin-bottom: 24px; line-height: 1.5; }
+        .btn-primary { width: 100%; padding: 16px; border-radius: 10px; border: none; background: #0099ff; color: #fff; font-size: 16px; font-weight: 600; cursor: pointer; transition: background 0.2s; display: block; text-decoration: none; }
+        .btn-primary:hover { background: #0088ee; }
+        .divider { margin: 24px 0; border-top: 1px solid #333; position: relative; }
+        .divider span { background: #1a1a1a; padding: 0 10px; color: #666; font-size: 12px; position: absolute; top: -9px; left: 50%; transform: translateX(-50%); }
+        input { width: 100%; padding: 14px; border-radius: 8px; border: 1px solid #333; background: #262626; color: #fff; margin-bottom: 14px; font-size: 14px; font-family: monospace; }
+        .btn-secondary { width: 100%; padding: 12px; border-radius: 8px; border: 1px solid #444; background: transparent; color: #ccc; font-size: 14px; cursor: pointer; }
+        .success { color: #4caf50; font-size: 18px; font-weight: 600; margin-top: 20px; display: none; }
+        .error { color: #f44336; font-size: 14px; margin-top: 15px; display: none; }
+    </style>
+</head>
+<body>
+    <div class="card" id="mainCard">
+        <h1>FloatNative TV Sign In</h1>
+        <p>Sign in on Floatplane.com to automatically connect your TV app!</p>
+
+        <button class="btn-primary" id="autoBtn" onclick="tryAutoSync()">Sign In with Floatplane</button>
+
+        <div class="divider"><span>OR PASTE MANUALLY</span></div>
+
+        <form id="manualForm">
+            <input type="text" id="cookieInput" placeholder="Paste sails.sid cookie (s%3A...)" required />
+            <button type="submit" class="btn-secondary" id="submitBtn">Submit Cookie</button>
+        </form>
+
+        <div id="success" class="success">✓ Signed in! Your TV is connecting now.</div>
+        <div id="error" class="error"></div>
+    </div>
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        const session = params.get('session');
+        const autoBtn = document.getElementById('autoBtn');
+        const manualForm = document.getElementById('manualForm');
+        const cookieInput = document.getElementById('cookieInput');
+        const submitBtn = document.getElementById('submitBtn');
+        const successEl = document.getElementById('success');
+        const errorEl = document.getElementById('error');
+
+        async function tryAutoSync() {
+            autoBtn.disabled = true;
+            autoBtn.textContent = 'Checking Floatplane session...';
+            errorEl.style.display = 'none';
+
+            try {
+                const res = await fetch('https://www.floatplane.com/api/v3/user/self', { credentials: 'include' });
+                if (res.ok) {
+                    let match = document.cookie.match(/(?:^|; )sails\.sid=([^;]*)/);
+                    if (match && match[1]) {
+                        submitCookie(decodeURIComponent(match[1]));
+                        return;
+                    }
+                }
+            } catch (err) {
+                console.log('CORS/Cookie check redirect needed');
+            }
+
+            window.location.href = 'https://www.floatplane.com/login';
+        }
+
+        async function submitCookie(sailsSid) {
+            try {
+                const res = await fetch('/auth/qr/submit', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ session_id: session, sails_sid: sailsSid })
+                });
+                if (res.ok) {
+                    autoBtn.style.display = 'none';
+                    manualForm.style.display = 'none';
+                    document.querySelector('.divider').style.display = 'none';
+                    successEl.style.display = 'block';
+                } else {
+                    const data = await res.json();
+                    showError(data.message || 'Failed to connect TV.');
+                }
+            } catch (err) {
+                showError('Network error. Please try again.');
+            }
+        }
+
+        manualForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            let cookie = cookieInput.value.trim();
+            if (cookie.startsWith('sails.sid=')) {
+                cookie = cookie.replace('sails.sid=', '').trim();
+            }
+            if (cookie) submitCookie(cookie);
+        });
+
+        function showError(msg) {
+            errorEl.textContent = msg;
+            errorEl.style.display = 'block';
+            autoBtn.disabled = false;
+            autoBtn.textContent = 'Sign In with Floatplane';
+        }
+    </script>
+</body>
+</html>`))
 }
 
 type LoginRequest struct {

--- a/packages/api-go/internal/router/router.go
+++ b/packages/api-go/internal/router/router.go
@@ -59,6 +59,8 @@ func New() *chi.Mux {
 	// Auth QR Routes (Public)
 	router.Post("/auth/qr/generate", handlers.GenerateQR)
 	router.Get("/auth/qr/poll/{id}", handlers.PollQR)
+	router.Post("/auth/qr/submit", handlers.SubmitQR)
+	router.Get("/public/qr-login.html", handlers.QRLoginHTML)
 	router.Post("/auth/login", handlers.Login)
 
 	return router

--- a/tools/floatcli/floatcli/cli.py
+++ b/tools/floatcli/floatcli/cli.py
@@ -126,6 +126,18 @@ def auth_refresh() -> None:
     console.print("[green]✓ Refreshed.[/green]")
 
 
+@auth_app.command("set-cookie")
+def auth_set_cookie(cookie: str = typer.Argument(..., help="sails.sid cookie string")) -> None:
+    """Save a sails.sid session cookie for requests."""
+    creds = _load_creds_or_die()
+    clean = cookie.strip()
+    if clean.startswith("sails.sid="):
+        clean = clean[len("sails.sid="):].strip()
+    creds.sails_sid = clean
+    creds.save()
+    console.print("[green]✓ sails.sid cookie saved.[/green]")
+
+
 @auth_app.command("logout")
 def auth_logout() -> None:
     """Delete saved credentials. Does NOT revoke server-side."""

--- a/tools/floatcli/floatcli/floatplane.py
+++ b/tools/floatcli/floatcli/floatplane.py
@@ -19,7 +19,7 @@ from .dpop import DPoPKey, generate_proof
 from .storage import Credentials
 
 API_BASE = "https://www.floatplane.com"
-USER_AGENT = "floatcli/0.1.0 (+https://github.com/coulterpeterson/FloatNative)"
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
 
 
 @dataclass
@@ -80,6 +80,8 @@ class FloatplaneClient:
         url = f"{API_BASE}{path}"
         headers: dict[str, str] = {}
         if authenticated:
+            if self.credentials.sails_sid:
+                headers["Cookie"] = f"sails.sid={self.credentials.sails_sid}"
             if self.credentials.is_expired:
                 self._refresh()
             access = self.credentials.access_token

--- a/tools/floatcli/floatcli/storage.py
+++ b/tools/floatcli/floatcli/storage.py
@@ -31,6 +31,7 @@ class Credentials:
     refresh_token: str | None
     expires_at: float  # epoch seconds
     companion_api_key: str | None = None
+    sails_sid: str | None = None
 
     @property
     def is_expired(self) -> bool:


### PR DESCRIPTION
- Replace non-browser User-Agents with browser-compatible strings across Android, iOS, and floatcli to prevent Cloudflare WAF 403 bot challenges
- Implement automagic sails.sid session cookie extraction from web authentication sessions (CookieManager on Android, HTTPCookieStorage on iOS)
- Ensure Cookie: sails.sid=<value> is attached to all authenticated API calls alongside OAuth DPoP/Bearer tokens
- Fix slash escaping (\/ -> /) in DPoP JWT claim proofs in DPoPManager
- Handle DPoP-Nonce response headers and WWW-Authenticate retry loops
- Clear invalid auth states on unresolvable 401/403 responses so the UI routes cleanly to login
- Add session cookie login buttons and fallback dialogs to LoginScreen, TvLoginScreen, and SettingsScreen
- Update floatcli with `auth set-cookie` command and browser User-Agent support

Fixes #52 